### PR TITLE
YPSA-1091 make button text appearance configurable

### DIFF
--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWithAppleButton.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWithAppleButton.kt
@@ -3,6 +3,7 @@ package com.willowtreeapps.signinwithapplebutton.view
 import android.content.Context
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
+import android.os.Build
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
@@ -11,11 +12,7 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
-import com.willowtreeapps.signinwithapplebutton.R
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleConfiguration
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleResult
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
+import com.willowtreeapps.signinwithapplebutton.*
 import com.willowtreeapps.signinwithapplebutton.toFunction
 
 class SignInWithAppleButton @JvmOverloads constructor(
@@ -47,6 +44,7 @@ class SignInWithAppleButton @JvmOverloads constructor(
         val textSize = attributes.getDimensionPixelSize(R.styleable.SignInWithAppleButton_android_textSize, -1)
         val textStyle = attributes.getInt(R.styleable.SignInWithAppleButton_android_textStyle, 0)
         val fontFamily = attributes.getString(R.styleable.SignInWithAppleButton_android_fontFamily)
+        val buttonTextAppearance = attributes.getResourceId(R.styleable.SignInWithAppleButton_sign_in_with_apple_button_textAppearance, -1)
 
         // Text type
         val text = attributes.getInt(
@@ -82,13 +80,20 @@ class SignInWithAppleButton @JvmOverloads constructor(
             textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize.toFloat())
         }
 
-        val typeface = if (fontFamily == null) {
-            Typeface.create(textView.typeface, textStyle)
+        if(buttonTextAppearance != -1) {
+            if(Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                textView.setTextAppearance(context, buttonTextAppearance)
+            } else {
+                textView.setTextAppearance(buttonTextAppearance)
+            }
         } else {
-            Typeface.create(fontFamily, textStyle)
+            val typeface = if (fontFamily == null) {
+                Typeface.create(textView.typeface, textStyle)
+            } else {
+                Typeface.create(fontFamily, textStyle)
+            }
+            textView.typeface = typeface
         }
-
-        textView.typeface = typeface
 
         textView.text = resources.getString(SignInTextType.values()[text].text)
     }

--- a/signinwithapplebutton/src/main/res/values/attrs.xml
+++ b/signinwithapplebutton/src/main/res/values/attrs.xml
@@ -18,6 +18,8 @@
             <enum name="continueWithApple" value="1" />
         </attr>
 
+        <attr name="sign_in_with_apple_button_textAppearance" format="reference"/>
+
         <!-- Corner radius -->
         <attr name="sign_in_with_apple_button_cornerRadius" format="dimension" />
     </declare-styleable>


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2FYPSA-1091)](https://netsells.atlassian.net/browse/YPSA-1091)

## Overview
- [x] I have performed a self review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have commented my code, particularly in hard-to-understand areas

### Problem statement
QA feedback - Apple Sign In Button font style is not consistent with other signin buttons on the login screen

### Solution
Although the sub module allowed for setting the button typeface, it did not allow setting other attributes like letterspacing etc.
So added a sign_in_with_apple_button_textAppearance custom attribute for the button allowing any textAppearance to be used by the consuming layouts.

### Links
JIRA: https://netsells.atlassian.net/browse/YPSA-1091

## Screenshots
### Before
![Screenshot_1605606321](https://user-images.githubusercontent.com/35679717/99781880-55917800-2b10-11eb-9a8f-b19570b9f4c8.png)

### After
![Screenshot_1605825205](https://user-images.githubusercontent.com/35679717/99781901-5cb88600-2b10-11eb-938a-8925f3cb91e3.png)
